### PR TITLE
Rename PerunToken to ERC20Token

### DIFF
--- a/contracts/ERC20Token.sol
+++ b/contracts/ERC20Token.sol
@@ -21,14 +21,14 @@ import "../vendor/openzeppelin-contracts/contracts/utils/Address.sol";
 import "../vendor/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "../vendor/openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
 
-contract PerunToken is ERC20 {
+contract ERC20Token is ERC20 {
     using SafeMath for uint256;
 
     /**
-     * @dev Creates a new PerunToken contract instance with `accounts` being
+     * @dev Creates a new ERC20Token contract instance with `accounts` being
      * funded with `initBalance` tokens.
      */
-    constructor (address[] memory accounts, uint256 initBalance) ERC20("PerunToken", "PRN") {
+    constructor (address[] memory accounts, uint256 initBalance) ERC20("ERC20Token", "ERC") {
         for (uint256 i = 0; i < accounts.length; i++) {
             _mint(accounts[i], initBalance);
         }

--- a/contracts/ERC20Token.sol
+++ b/contracts/ERC20Token.sol
@@ -25,10 +25,16 @@ contract ERC20Token is ERC20 {
     using SafeMath for uint256;
 
     /**
-     * @dev Creates a new ERC20Token contract instance with `accounts` being
-     * funded with `initBalance` tokens.
+     * @dev Creates a new ERC20Token contract instance with the given `name`,
+     * `code`, and `accounts` being funded with `initBalance` tokens.
      */
-    constructor (address[] memory accounts, uint256 initBalance) ERC20("ERC20Token", "ERC") {
+    constructor (
+        string memory name,
+        string memory code,
+        address[] memory accounts,
+        uint256 initBalance)
+    ERC20(name, code)
+    {
         for (uint256 i = 0; i < accounts.length; i++) {
             _mint(accounts[i], initBalance);
         }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -15,7 +15,7 @@
 var Adjudicator = artifacts.require("Adjudicator");
 var AssetHolderETH = artifacts.require("AssetHolderETH");
 var AssetHolderERC20 = artifacts.require("AssetHolderERC20");
-var PerunToken = artifacts.require("PerunToken");
+var ERC20Token = artifacts.require("ERC20Token");
 var Channel = artifacts.require("Channel");
 
 module.exports = async function(deployer, _network, accounts) {
@@ -24,6 +24,6 @@ module.exports = async function(deployer, _network, accounts) {
   await deployer.deploy(Adjudicator);
 
   await deployer.deploy(AssetHolderETH, Adjudicator.address);
-  await deployer.deploy(PerunToken, accounts, 1<<10);
-  await deployer.deploy(AssetHolderERC20, Adjudicator.address, PerunToken.address);
+  await deployer.deploy(ERC20Token, accounts, 1<<10);
+  await deployer.deploy(AssetHolderERC20, Adjudicator.address, ERC20Token.address);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -24,6 +24,6 @@ module.exports = async function(deployer, _network, accounts) {
   await deployer.deploy(Adjudicator);
 
   await deployer.deploy(AssetHolderETH, Adjudicator.address);
-  await deployer.deploy(ERC20Token, accounts, 1<<10);
+  await deployer.deploy(ERC20Token, "PerunToken", "PRN", accounts, 1<<10);
   await deployer.deploy(AssetHolderERC20, Adjudicator.address, ERC20Token.address);
 };

--- a/src/test/AssetHolderERC20.ts
+++ b/src/test/AssetHolderERC20.ts
@@ -30,7 +30,7 @@ contract("AssetHolderERC20", (accounts: any) => {
   let setup: AssetHolderSetup = new AssetHolderSetup(undefined, accounts, deposit, balanceOf);
 
   it("should deploy the ERC20Token contract", async () => {
-    token = await ERC20Token.new(accounts, ether(100));
+    token = await ERC20Token.new("PerunToken", "PRN", accounts, ether(100));
   });
 
   it("should deploy the AssetHolderERC20 contract", async () => {

--- a/src/test/AssetHolderERC20.ts
+++ b/src/test/AssetHolderERC20.ts
@@ -15,22 +15,22 @@
 import { should } from "chai";
 should();
 const truffleAssert = require('truffle-assertions');
-import { AssetHolderERC20Contract, PerunTokenContract, PerunTokenInstance } from "../../types/truffle-contracts";
+import { AssetHolderERC20Contract, ERC20TokenContract, ERC20TokenInstance } from "../../types/truffle-contracts";
 import { ether } from "../lib/web3";
 import { AssetHolderSetup } from "./Setup";
 import { genericAssetHolderTest } from "./AssetHolder";
 
 const AssetHolderERC20 = artifacts.require<AssetHolderERC20Contract>("AssetHolderERC20");
-const PerunToken = artifacts.require<PerunTokenContract>("PerunToken");
+const ERC20Token = artifacts.require<ERC20TokenContract>("ERC20Token");
 
 contract("AssetHolderERC20", (accounts: any) => {
-  let token: PerunTokenInstance;
+  let token: ERC20TokenInstance;
   // Pass `undefined` as AssetHolder and set it in the deploy step.
   // Needed because of how mocha binds variables.
   let setup: AssetHolderSetup = new AssetHolderSetup(undefined, accounts, deposit, balanceOf);
 
-  it("should deploy the PerunToken contract", async () => {
-    token = await PerunToken.new(accounts, ether(100));
+  it("should deploy the ERC20Token contract", async () => {
+    token = await ERC20Token.new(accounts, ether(100));
   });
 
   it("should deploy the AssetHolderERC20 contract", async () => {


### PR DESCRIPTION
This PR renames PerunToken to ERC20Token and allows to set a custom name and symbol for the ERC20 contract.